### PR TITLE
Set private flag to false for tutorials tracks

### DIFF
--- a/instruqt-tracks/build-custom-gcp-images/track.yml
+++ b/instruqt-tracks/build-custom-gcp-images/track.yml
@@ -12,6 +12,6 @@ tags: []
 owner: tutorials
 developers:
 - sean@instruqt.com
-private: true
+private: false
 published: true
 checksum: "10491803794319181302"

--- a/instruqt-tracks/google-artifact-registry-container/track.yml
+++ b/instruqt-tracks/google-artifact-registry-container/track.yml
@@ -12,6 +12,6 @@ tags: []
 owner: tutorials
 developers:
 - sean@instruqt.com
-private: true
+private: false
 published: true
 checksum: "6894112894271722217"

--- a/instruqt-tracks/instruqt-with-terraform/track.yml
+++ b/instruqt-tracks/instruqt-with-terraform/track.yml
@@ -21,6 +21,6 @@ tags:
 owner: tutorials
 developers:
 - sean@instruqt.com
-private: true
+private: false
 published: true
 checksum: "2692280470090607213"


### PR DESCRIPTION
See https://instruqt.slack.com/archives/C0113Q31LCE/p1658911182057529 for context.

This fix is needed to ensure all tracks are visible on the inspiration library with the team page v2 flag disabled. We need a proper fix for the inspiration library to ensure tracks remains visible after fully deprecating public access.